### PR TITLE
Fix incorrect time unit

### DIFF
--- a/tyk-docs/content/shared/gateway-config.md
+++ b/tyk-docs/content/shared/gateway-config.md
@@ -203,7 +203,7 @@ This option does not give any hints to the client, on which certificate to pick 
 EV: <b>TYK_GW_HTTPSERVEROPTIONS_FLUSHINTERVAL</b><br />
 Type: `int`<br />
 
-Set this to the number of seconds that Tyk uses to flush content from the proxied upstream connection to the open downstream connection.
+Set this to the number of milliseconds that Tyk uses to flush content from the proxied upstream connection to the open downstream connection.
 This option needed be set for streaming protocols like Server Side Events, or gRPC streaming.
 
 ### http_server_options.skip_url_cleaning


### PR DESCRIPTION
The docs say seconds here, but the implementation says milliseconds, see [here](https://github.com/TykTechnologies/tyk/blob/3799d4f3e2293bc1781cd791306281efcd7fc21c/gateway/reverse_proxy.go#L323)

### For internal users - Please add a Jira DX PR ticket to the subject!
<br>

---

### Preview Link

https://github.com/djablonski-moia/tyk-docs/content/shared/gateway-config.md
<br>

### Description

The file `tyk-docs/content/shared/gateway-config.md` states that the time unit for `http_server_options.flush_interval` is seconds, while the implementation uses milliseconds, as to be seen [here](https://github.com/TykTechnologies/tyk/blob/3799d4f3e2293bc1781cd791306281efcd7fc21c/gateway/reverse_proxy.go#L323.

This PR only replaces `seconds` with `milliseconds` in the mentioned file.

)
<!-- 1. Describe your changes in detail. Why is this change required? What problem does it solve?
     2. Please explain the change to the reviewer. Pay special attention to changes that are hard to spot, 
       for example:
       2.1. Name change in the file name or directory name - please flag it out since it’s hard 
            to compare text after such a change 
       2.2. Terminology change - flag it out to make sure the reviewer is aware before approving
     3. @mentions of the person to review the proposed changes. They need to be able to know the topic well in order to approve it.
-->
<br>

#### Screenshots (if appropriate)
<br>

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have added a **preview link** to the PR description.
- [ ] I have [reviewed the guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING.md) for contributing to this repository.
- [ ] I have [read the technical guidelines](https://github.com/TykTechnologies/tyk-docs/blob/master/CONTRIBUTING-TECHNICAL-GUIDE.md) for contributing to this repository.
- [ ] Make sure you have started *your change* off *our latest `master`*.
- [ ] I **labelled** the PR
<!-- Label your PR according to the type of changes that your code introduces. This ensures that we know how/when to publish the PR. These are the options:
- Fixing typo (please merge to production) - add the label `now`
- Documenting a new feature (please merge to production) - add the label `now`
- Documentation for future release (please do not merge to production) - add label `future release` and label of the release
- [Something else (please add if needs merging to production or not) - add label according to the above logic -->
